### PR TITLE
fix(bug): node config and sibling route

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ describe('api', function() {
   ...
 
   afterEach(function() {
-    api.state.reset();
+    api.state.resetAll();
   });
 })
 ```
@@ -131,21 +131,33 @@ var api = new ApiMockServer({
 ## State API
 
 ### Set
-Set a route to demanded status
+Set a route to demanded state
 ```js
 api.state.set('/users/:id', 'GET', 404);
 ```
 
 ### Get
-Get a route status
+Get a route state
 ```js
 api.state.get('/users/:id', 'GET');
 ```
 
+### Get All
+Get all route states
+```js
+api.state.getAll();
+```
+
 ### Reset
+Reset a state to 200
+```js
+api.state.reset('/users/:id', 'GET');
+```
+
+### Reset All
 Reset all routes to 200
 ```js
-api.state.reset();
+api.state.resetAll();
 ```
 
 # TODO

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "api-error-handler": "^1.0.0",
     "body-parser": "^1.15.2",
-    "config": "^1.21.0",
     "express": "^4.14.0",
     "fs-extra": "^0.30.0",
     "lodash": "^4.14.1"

--- a/src/server/app/libs/options.js
+++ b/src/server/app/libs/options.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var defaultOptions = require('config').get('defaultOptions');
+var defaultOptions = require(path.join(__dirname, '../../../../', 'config/default')).defaultOptions;
 var _options = {};
 
 function init(options) {

--- a/src/server/app/routes/dynamicRoutes/index.js
+++ b/src/server/app/routes/dynamicRoutes/index.js
@@ -11,6 +11,12 @@ var constructRoutes = function(items) {
     router[item.verb](item.route, function(req, res, next) { //eslint-disable-line no-unused-vars
       var s = Libs.state.get(item.route, item.verb);
 
+      if (!_.isEmpty(req.params) && _.has(Libs.state.getAll(), req.path + '.' + _.upperCase(item.verb))) {
+        return next('route');
+      }
+
+      debug(req.path + ' called. Current state is ' + s + '. Route is ' + req.route.path);
+
       if (s !== 200) {
         var json;
         var pathToRequire = path.join(item.dir, item.verb + '-' + s + item.ext);

--- a/tests/api-mocks/users/email/get.json
+++ b/tests/api-mocks/users/email/get.json
@@ -1,0 +1,3 @@
+{
+  "what": "get an email"
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -63,6 +63,17 @@ describe('[API]', function() {
     });
   });
 
+  describe('/users/email', function() {
+    it('should respond with 200', function(done) {
+      request(app)
+        .get('/users/email')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200, {what: 'get an email'}, done)
+      ;
+    });
+  });
+
   describe('/users/id/player', function() {
     it('should respond with 200', function(done) {
       request(app)


### PR DESCRIPTION
- node config does not work in node_modules, it was useless, it has been removed
- /users/:id was called when a sibling route was called like /users/email, now it will check if route exist
